### PR TITLE
Switch amazon domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+AMAZON_USERNAME=your_amazon_username

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.env

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ This little application will fetch a list of all your highlights from your kindl
 ## Usage
 
     kindle # Will prompt you for your login info. Don't worry it isn't stored.
-    
+
+### Preserve Amazon username on your local machine
+
+    cp .env.sample .env
+
+And then, change your username `AMAZON_USERNAME` in _.env_
+
 ## Other usage and license
 
 Hastily thrown together but incredibly useful since Amazon does not provide an API for kindle highlights. Please use this however you would like. This is licensed under MIT license.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This little application will fetch a list of all your highlights from your kindl
 
 And then, change your username `AMAZON_USERNAME` in _.env_
 
+### Fetch highlights of different domain
+
+Add `KINDLE_DOMAIN=amazon.co.jp` to _.env_ (Example: Japanese site)
+
 ## Other usage and license
 
 Hastily thrown together but incredibly useful since Amazon does not provide an API for kindle highlights. Please use this however you would like. This is licensed under MIT license.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kindle Highlights Fetcher
 
-This little application will fetch a list of all your highlights from your kindle ebooks. 
+This little application will fetch a list of all your highlights from your kindle ebooks.
 
 ## Installation
 
@@ -21,5 +21,5 @@ And then, change your username `AMAZON_USERNAME` in _.env_
 Hastily thrown together but incredibly useful since Amazon does not provide an API for kindle highlights. Please use this however you would like. This is licensed under MIT license.
 
 
-© 2012 Matt Petty 
+© 2012 Matt Petty
 [@lodestone](http://about.me/lodestone)

--- a/bin/kindle
+++ b/bin/kindle
@@ -3,7 +3,12 @@
 require_relative "../lib/kindle"
 require 'highline/import'
 
-login = ask("Enter your Amazon.com username:  ") { |q| q.echo = true } unless login = ARGV[0]
+login = if amazon_username = ENV['AMAZON_USERNAME']
+  puts "Using Amazon.com username: #{amazon_username}"
+  amazon_username
+else
+  ask("Enter your Amazon.com username:  ") { |q| q.echo = true } unless login = ARGV[0]
+end
 passwd = ask("Enter your Amazon.com password (This is not stored):  ") { |q| q.echo = "*" }
 
 begin

--- a/kindle.gemspec
+++ b/kindle.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri"
   s.add_dependency "highline"
   s.add_dependency "mechanize"
+  s.add_dependency "dotenv"
 end

--- a/lib/kindle.rb
+++ b/lib/kindle.rb
@@ -1,3 +1,5 @@
+require 'dotenv'
+Dotenv.load
 require 'nokogiri'
 require 'mechanize'
 require_relative 'kindle/highlight'

--- a/lib/kindle/highlights_parser.rb
+++ b/lib/kindle/highlights_parser.rb
@@ -4,8 +4,9 @@ module Kindle
 
     include Nokogiri
 
-    KINDLE_URL = 'http://kindle.amazon.com'
-    KINDLE_HTTPS_URL = 'https://kindle.amazon.com'
+    KINDLE_DOMAIN = 'amazon.com'
+    KINDLE_URL = "http://kindle.#{KINDLE_DOMAIN}"
+    KINDLE_HTTPS_URL = "https://kindle.#{KINDLE_DOMAIN}"
 
     def initialize(options = {:login => nil, :password => nil})
       options.each_pair { |k,v| instance_variable_set("@#{k}", v) }
@@ -85,7 +86,7 @@ module Kindle
       asins_string    = asins.collect { |asin| "used_asins[]=#{asin}" } * '&'
       upcoming_string = state[:current_upcoming].map { |l| "upcoming_asins[]=#{l}" } * '&'
       url = "#{KINDLE_HTTPS_URL}/your_highlights/next_book?#{asins_string}&current_offset=#{state[:current_offset]}&#{upcoming_string}"
-      ajax_headers = { 'X-Requested-With' => 'XMLHttpRequest', 'Host' => 'kindle.amazon.com' }
+      ajax_headers = { 'X-Requested-With' => 'XMLHttpRequest', 'Host' => "kindle.#{KINDLE_DOMAIN}" }
       page = agent.get(url,[],"#{KINDLE_HTTPS_URL}/your_highlight", ajax_headers)
 
       initialize_state_with_page state, page

--- a/lib/kindle/highlights_parser.rb
+++ b/lib/kindle/highlights_parser.rb
@@ -3,7 +3,7 @@ module Kindle
   class HighlightsParser
 
     include Nokogiri
-    
+
     KINDLE_URL = 'http://kindle.amazon.com'
 
     def initialize(options = {:login => nil, :password => nil})
@@ -73,7 +73,7 @@ module Kindle
 
     def initialize_state_with_page(state, page)
       return if (page/".yourHighlight").length == 0
-      state[:current_upcoming] = (page/".upcoming").first.text.split(',') rescue [] 
+      state[:current_upcoming] = (page/".upcoming").first.text.split(',') rescue []
       state[:title] = (page/".yourHighlightsHeader .title").text.to_s.strip
       state[:author] = (page/".yourHighlightsHeader .author").text.to_s.strip
       state[:current_offset] = ((page/".yourHighlightsHeader").collect{|h| h.attributes['id'].value }).first.split('_').last

--- a/lib/kindle/highlights_parser.rb
+++ b/lib/kindle/highlights_parser.rb
@@ -5,6 +5,7 @@ module Kindle
     include Nokogiri
 
     KINDLE_URL = 'http://kindle.amazon.com'
+    KINDLE_HTTPS_URL = 'https://kindle.amazon.com'
 
     def initialize(options = {:login => nil, :password => nil})
       options.each_pair { |k,v| instance_variable_set("@#{k}", v) }
@@ -32,7 +33,7 @@ module Kindle
 
     def get_login_page
       page = agent.get(KINDLE_URL)
-      page.link_with(href: "https://kindle.amazon.com/login").click
+      page.link_with(href: "#{KINDLE_HTTPS_URL}/login").click
     end
 
     def login
@@ -83,9 +84,9 @@ module Kindle
       asins           = previously_extracted_highlights.map(&:asin).uniq
       asins_string    = asins.collect { |asin| "used_asins[]=#{asin}" } * '&'
       upcoming_string = state[:current_upcoming].map { |l| "upcoming_asins[]=#{l}" } * '&'
-      url = "https://kindle.amazon.com/your_highlights/next_book?#{asins_string}&current_offset=#{state[:current_offset]}&#{upcoming_string}"
+      url = "#{KINDLE_HTTPS_URL}/your_highlights/next_book?#{asins_string}&current_offset=#{state[:current_offset]}&#{upcoming_string}"
       ajax_headers = { 'X-Requested-With' => 'XMLHttpRequest', 'Host' => 'kindle.amazon.com' }
-      page = agent.get(url,[],'https://kindle.amazon.com/your_highlight', ajax_headers)
+      page = agent.get(url,[],"#{KINDLE_HTTPS_URL}/your_highlight", ajax_headers)
 
       initialize_state_with_page state, page
 

--- a/lib/kindle/highlights_parser.rb
+++ b/lib/kindle/highlights_parser.rb
@@ -4,7 +4,7 @@ module Kindle
 
     include Nokogiri
 
-    KINDLE_DOMAIN = 'amazon.com'
+    KINDLE_DOMAIN = ENV['KINDLE_DOMAIN'] || 'amazon.com'
     KINDLE_URL = "http://kindle.#{KINDLE_DOMAIN}"
     KINDLE_HTTPS_URL = "https://kindle.#{KINDLE_DOMAIN}"
 


### PR DESCRIPTION
This feature allows to user to switch amazon domain by adding `KINDLE_DOMAIN=amazon.co.jp` to _.env_ .

I tested on amazon.co.jp and amazon.com .

If it works with amazon.com on your environment, please accept this.
